### PR TITLE
bugfix: Check bitbake result

### DIFF
--- a/meta-ubinux/scripts/srpm-build_armv8.sh
+++ b/meta-ubinux/scripts/srpm-build_armv8.sh
@@ -27,6 +27,5 @@ if [ ${#failed_recipes[@]} -ne 0 ]; then
   for failed in "${failed_recipes[@]}"; do
     echo " - $failed"
   done
-else
-  echo "armv8 Result: All deployments completed successfully."
+  exit 1
 fi

--- a/meta-ubinux/scripts/srpm-build_armv8.sh
+++ b/meta-ubinux/scripts/srpm-build_armv8.sh
@@ -1,12 +1,32 @@
 #!/bin/bash
-bitbake libevent -f -c deploy_archives
-bitbake swupdate -f -c deploy_archives
-bitbake restool -f -c deploy_archives
-bitbake openjdk-8 -f -c deploy_archives
-bitbake giflib -f -c deploy_archives
-bitbake libiodbc -f -c deploy_archives
-bitbake pgpool2 -f -c deploy_archives
-bitbake psqlodbc -f -c deploy_archives
-bitbake unixodbc -f -c deploy_archives
-bitbake libmemcached -f -c deploy_archives
-bitbake libubootenv -f -c deploy_archives
+recipes=(
+  libevent
+  swupdate
+  restool
+  openjdk-8
+  giflib
+  libiodbc
+  pgpool2
+  psqlodbc
+  unixodbc
+  libmemcached
+  libubootenv
+)
+
+failed_recipes=()
+
+for recipe in "${recipes[@]}"; do
+  if ! bitbake "$recipe" -f -c deploy_archives; then
+    echo "ERROR: Failed to deploy $recipe"
+    failed_recipes+=("$recipe")
+  fi
+done
+
+if [ ${#failed_recipes[@]} -ne 0 ]; then
+  echo "armv8 Result: The following recipes failed to deploy:"
+  for failed in "${failed_recipes[@]}"; do
+    echo " - $failed"
+  done
+else
+  echo "armv8 Result: All deployments completed successfully."
+fi

--- a/meta-ubinux/scripts/srpm-build_lib32-x86.sh
+++ b/meta-ubinux/scripts/srpm-build_lib32-x86.sh
@@ -27,6 +27,5 @@ if [ ${#failed_recipes[@]} -ne 0 ]; then
   for failed in "${failed_recipes[@]}"; do
     echo " - $failed"
   done
-else
-  echo "lib32-x86 Result: All deployments completed successfully."
+  exit 1
 fi

--- a/meta-ubinux/scripts/srpm-build_lib32-x86.sh
+++ b/meta-ubinux/scripts/srpm-build_lib32-x86.sh
@@ -1,12 +1,32 @@
 #!/bin/bash
-bitbake lib32-open-iscsi-user -f -c deploy_archives
-bitbake lib32-jssocket -f -c deploy_archives
-bitbake  lib32-libjs-jquery-cookie -f -c deploy_archives
-bitbake  lib32-libjs-jquery-custom-scrollbar -f -c deploy_archives
-bitbake  lib32-libjs-jquery-dropkick -f -c deploy_archives
-bitbake  lib32-libjs-jquery-globalize -f -c deploy_archives
-bitbake  lib32-libjs-jquery-icheck -f -c deploy_archives
-bitbake  lib32-libjs-jquery-mousewheel -f -c deploy_archives
-bitbake  lib32-libjs-jquery-ui -f -c deploy_archives
-bitbake  lib32-smarty -f -c deploy_archives
-bitbake  lib32-apcupsd -f -c deploy_archives
+recipes=(
+  lib32-open-iscsi-user
+  lib32-jssocket
+  lib32-libjs-jquery-cookie
+  lib32-libjs-jquery-custom-scrollbar
+  lib32-libjs-jquery-dropkick
+  lib32-libjs-jquery-globalize
+  lib32-libjs-jquery-icheck
+  lib32-libjs-jquery-mousewheel
+  lib32-libjs-jquery-ui
+  lib32-smarty
+  lib32-apcupsd
+)
+
+failed_recipes=()
+
+for recipe in "${recipes[@]}"; do
+  if ! bitbake "$recipe" -f -c deploy_archives; then
+    echo "ERROR: Failed to deploy $recipe"
+    failed_recipes+=("$recipe")
+  fi
+done
+
+if [ ${#failed_recipes[@]} -ne 0 ]; then
+  echo "lib32-x86 Result: The following recipes failed to deploy:"
+  for failed in "${failed_recipes[@]}"; do
+    echo " - $failed"
+  done
+else
+  echo "lib32-x86 Result: All deployments completed successfully."
+fi


### PR DESCRIPTION
This update adds error checks after each bitbake command. Without these checks, the workflow might not detect bitbake failures, which could lead to incomplete artifacts.